### PR TITLE
feat: Added attributes parsing + support for standard HTML tags

### DIFF
--- a/DOM.hs
+++ b/DOM.hs
@@ -1,13 +1,13 @@
 module DOM where
 
--- import qualified Data.Map as Map
+import qualified Data.Map as M
 
--- type HTMLAttributes = Map.Map String String
+type HTMLAttributes = M.Map String String
 type HTMLTag = String
 type HTMLContent = String
 
 data DOMTree = EmptyTree 
-    | HTMLElement HTMLTag [DOMTree]  
+    | HTMLElement HTMLTag HTMLAttributes [DOMTree]  
     | TextNode HTMLContent
     deriving (Show, Eq)
 
@@ -15,6 +15,6 @@ addElement :: DOMTree -> DOMTree -> DOMTree
 addElement tree el = EmptyTree
 
 tagName :: DOMTree -> HTMLTag
-tagName (HTMLElement tagName@(head:tail) _)  
+tagName (HTMLElement tagName@(head:tail) _ _)  
     | head == '/' = tail
     | otherwise = tagName

--- a/Grammar.hs
+++ b/Grammar.hs
@@ -13,11 +13,10 @@ import DOM (DOMTree(HTMLElement), tagName)
 
 html :: Parser DOMTree
 html = do
-    tagTree <- tagOpen
+    (HTMLElement openTagName attributes children) <- tagOpen
     children <- many' (textParser <|> html)
-    tagCloseTree <- tagClose
-    if tagName tagTree /= tagName tagCloseTree
-        then Parser $ \input -> Left [TagsNotMatched]
-    else return (HTMLElement (tagName tagTree) children)
+    (HTMLElement closeTagName _ _) <- tagClose
+    if openTagName /= tail closeTagName then Parser $ \input -> Left [TagsNotMatched]
+    else return (HTMLElement openTagName attributes children)
 -- this does not *properly* take into account the matching of tags yet
 -- we should handle error propagation and aggregation properly.


### PR DESCRIPTION
# Attribute parsing
- Added parsers that handle attributes.
- Added a tags list that represents the valid HTML tags.
- The `choice` parser handles a list of strings and succeeds if one of them matches.